### PR TITLE
(ignore) Harden actions/checkout: persist-credentials: false in codeql & dependency-review

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,5 +23,7 @@ jobs:
 
       - name: 'Checkout Repository'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@5a2ce3f5b92ee19cbb1541a4984c76d921601d7c # v4.3.4


### PR DESCRIPTION
## Summary

Hardens two GitHub Actions workflows by setting `persist-credentials: false` on their `actions/checkout` steps, so `GITHUB_TOKEN` is not persisted into the PR worktree.

Files changed:
- `.github/workflows/codeql.yml`
- `.github/workflows/dependency-review.yml`

This follows the prior read-only audit recommendation recorded at `C:\project-dina-ai-dev-tools\projects\azure-ai-tools\reports\research-2026-07-16-0958-azure-typescript-e2e-apps-workflow-secrets.md`.

No behavior change is intended beyond reducing token exposure in the checked-out workspace.